### PR TITLE
Update configure.ac to work with newer autoconf.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,8 @@ if test "x$LEX" != xflex; then
 fi
 
 AC_PROG_YACC
-if test "x$YACC" != "xbison -y"; then
+set -- $YACC
+if test "x$1" != "xbison"; then
   echo "************************"
   echo "bison not found"
   echo "************************"


### PR DESCRIPTION
Modern autoconf has changed its `bison` testing such that when found,
the `YACC` variable will be set to the string `bison -o y.tab.c` instead of
`bison -y`. Testing `$YACC` for the explicit value `bison -y` makes this
script very brittle, to the point that it breaks under the modern Autoconf,
even though a working `bison` _has_ been found.

By simply testing if the first word of `$YACC` is `bison`, the presence of `bison`
can be correctly ascertained under the behavior of both older and newer versions of
autoconf.

# SYMPTOMS

Under autoconf 2.69.3 on a FreeBSD 12.1 system with bison
3.4.2 installed, the `configure` script generated by `configure.ac`
bombs out with this message:

```
checking for bison... bison -o y.tab.c
************************
bison not found
************************
```